### PR TITLE
Replaced deprecated textAlignment: and lineBreakMode: properties

### DIFF
--- a/DWTagList/Classes/DWTagList.m
+++ b/DWTagList/Classes/DWTagList.m
@@ -101,7 +101,7 @@
         }
         [label setTextColor:TEXT_COLOR];
         [label setText:text];
-        [label setTextAlignment:NSLineBreakByWordWrapping];
+        [label setTextAlignment:NSTextAlignmentCenter];
         [label setShadowColor:TEXT_SHADOW_COLOR];
         [label setShadowOffset:TEXT_SHADOW_OFFSET];
         [label.layer setMasksToBounds:YES];


### PR DESCRIPTION
Sorry about the former pull request, I made a copy-paste mistake so I was using a NSLineBreakMode property for the text alignment. Both are fixed correctly now.
