### PR TITLE
Adding optional UIMenuController support with copy/delete per tag.

### DIFF
--- a/DWTagList/Classes/DWTagList.h
+++ b/DWTagList/Classes/DWTagList.h
@@ -7,13 +7,7 @@
 
 #import <UIKit/UIKit.h>
 
-@protocol DWTagListDelegate <NSObject>
-
-@required
-
-- (void)selectedTag:(NSString*)tagName;
-
-@end
+@protocol DWTagListDelegate, DWTagViewDelegate;
 
 @interface DWTagList : UIScrollView
 {
@@ -24,6 +18,7 @@
 }
 
 @property (nonatomic) BOOL viewOnly;
+@property (nonatomic) BOOL showTagMenu;
 @property (nonatomic, strong) UIView *view;
 @property (nonatomic, strong) NSArray *textArray;
 @property (nonatomic, weak) id<DWTagListDelegate> tagDelegate;
@@ -52,8 +47,9 @@
 
 @interface DWTagView : UIView
 
-@property (nonatomic, strong) UIButton      *button;
-@property (nonatomic, strong) UILabel       *label;
+@property (nonatomic, strong) UIButton              *button;
+@property (nonatomic, strong) UILabel               *label;
+@property (nonatomic, weak)   id<DWTagViewDelegate> delegate;
 
 - (void)updateWithString:(NSString*)text
                     font:(UIFont*)font
@@ -67,5 +63,23 @@
 - (void)setTextColor:(UIColor*)textColor;
 - (void)setTextShadowColor:(UIColor*)textShadowColor;
 - (void)setTextShadowOffset:(CGSize)textShadowOffset;
+
+@end
+
+
+@protocol DWTagListDelegate <NSObject>
+
+@optional
+
+- (void)selectedTag:(NSString *)tagName;
+- (void)tagListTagsChanged:(DWTagList *)tagList;
+
+@end
+
+@protocol DWTagViewDelegate <NSObject>
+
+@required
+
+- (void)tagViewWantsToBeDeleted:(DWTagView *)tagView;
 
 @end


### PR DESCRIPTION
I had a need in my project for the ability to delete tags in the tag list. Seemed like a clean way to do this was through `UIMenuController`, so I rolled in support for both `copy:` and `delete:` functions.

In doing so, I had to add a new delegate protocol for `DWTagView` in order to notify its parent `DWTagList` that it wants to be deleted (thanks to the strange convention of `UIMenuController`). I also added a new delegate method in the `DWTagListDelegate` protocol to notify the delegate that the tag list had changed (a new condition altogether, since tags were essentially immutable).

Let me know if you need anything else different in this pull request; I'm happy to oblige. It should be 1=1 compatible with existing projects, since the external API hasn't really changed, and the default behavior is to have the menu off.

Thanks for making this library!
